### PR TITLE
Workaround for .move change that isn't a move (indexpath == newindexpath)

### DIFF
--- a/Source/DATASource+NSFetchedResultsControllerDelegate.swift
+++ b/Source/DATASource+NSFetchedResultsControllerDelegate.swift
@@ -77,7 +77,7 @@ extension DATASource: NSFetchedResultsControllerDelegate {
                 if let indexPath = indexPath, let newIndexPath = newIndexPath {
                     // Workaround: Updating a UITableView element sometimes will trigger a .Move change
                     // where both indexPaths are the same, as a workaround if this happens, DATASource
-                    // will treat this change as an .Update
+                    // will treat this change as an .Update, based on the workaround below for CollectionView
                     if indexPath == newIndexPath {
                         if let cell = tableView.cellForRow(at: newIndexPath) {
                             self.configure(cell, indexPath: newIndexPath)

--- a/Source/DATASource+NSFetchedResultsControllerDelegate.swift
+++ b/Source/DATASource+NSFetchedResultsControllerDelegate.swift
@@ -75,11 +75,24 @@ extension DATASource: NSFetchedResultsControllerDelegate {
                 break
             case .move:
                 if let indexPath = indexPath, let newIndexPath = newIndexPath {
-                    tableView.deleteRows(at: [indexPath], with: rowAnimationType)
-                    tableView.insertRows(at: [newIndexPath], with: rowAnimationType)
+                    // Workaround: Updating a UITableView element sometimes will trigger a .Move change
+                    // where both indexPaths are the same, as a workaround if this happens, DATASource
+                    // will treat this change as an .Update
+                    if indexPath == newIndexPath {
+                        if let cell = tableView.cellForRow(at: newIndexPath) {
+                            self.configure(cell, indexPath: newIndexPath)
+                        }
 
-                    if let anObject = anObject as? NSManagedObject {
-                        self.delegate?.dataSource?(self, didMoveObject: anObject, fromIndexPath: indexPath, toIndexPath: newIndexPath)
+                        if let anObject = anObject as? NSManagedObject {
+                            self.delegate?.dataSource?(self, didUpdateObject: anObject, atIndexPath: newIndexPath)
+                        }
+                    } else {
+                        tableView.deleteRows(at: [indexPath], with: rowAnimationType)
+                        tableView.insertRows(at: [newIndexPath], with: rowAnimationType)
+
+                        if let anObject = anObject as? NSManagedObject {
+                            self.delegate?.dataSource?(self, didMoveObject: anObject, fromIndexPath: indexPath, toIndexPath: newIndexPath)
+                        }
                     }
                 }
                 break


### PR DESCRIPTION
It seems there was already a workaround for this when working with CollectionViews. It turns out the same can happen for tableViews. I've implemented the same workaround for TableViews